### PR TITLE
Use PNG logo, ask for player name, and show power-up icons

### DIFF
--- a/dragonfly_game.html
+++ b/dragonfly_game.html
@@ -74,6 +74,7 @@
     }
     .shield { background: linear-gradient(180deg, #7fd1ff 0%, #5cc8ff 100%); }
     .speed { background: linear-gradient(180deg, #ff7f7f 0%, #ff5c5c 100%); }
+    .magnet { background: linear-gradient(180deg, #ffd36b 0%, #ffb347 100%); }
     h1 { margin: 0 0 8px 0; font-size: clamp(22px, 2.4vw, 36px); letter-spacing: .5px; }
     p { margin: 6px 0; opacity: .95; }
     kbd { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; background: rgba(0,137,137,.12); padding: 2px 6px; border-radius: 6px; border: 1px solid rgba(0,137,137,.25); }
@@ -81,6 +82,7 @@
     .btn:active { transform: translateY(1px); }
     .touch-hint { display: none; }
     @media (pointer: coarse) { .touch-hint { display: inline; } }
+    .name-input { width: 100%; padding: 8px 10px; border-radius: 8px; border: 1px solid rgba(0,137,137,.25); margin-top: 14px; }
   </style>
 </head>
 <body>
@@ -95,18 +97,13 @@
     <div class="overlay" id="overlay">
       <div class="card">
         <div style="text-align: center; margin-bottom: 15px;">
-          <svg xmlns="http://www.w3.org/2000/svg" width="120" height="42" viewBox="0 0 150 52.5" style="margin-bottom: 5px;">
-            <path fill="#008989" d="M54.64,27.4a13.92,13.92,0,0,0-1.12-5.68,13.79,13.79,0,1,0-4.8,15.92,14,14,0,0,0,4.24-4.56A14.49,14.49,0,0,0,54.64,27.4M61,27.4A21,21,0,0,1,32.63,46.23,21,21,0,0,1,32.63,8.57,21,21,0,0,1,61,27.4"/>
-            <path fill="#008989" d="M65.56,42.82H71V24.65h5.4v-4.5H71V13.73H65.56v6.42H62.23v4.5h3.33Z"/>
-            <path fill="#008989" d="M80.82,31.36a11.69,11.69,0,0,0,11.72,12,13.17,13.17,0,0,0,7-1.92V36.75H93.25v4.27a8.41,8.41,0,0,1-1,.31,8.17,8.17,0,0,1-6.43-.87,7.61,7.61,0,0,1-3.49-7.1,7.62,7.62,0,0,1,3.49-7.1,8.16,8.16,0,0,1,6.43-.88,8.34,8.34,0,0,1,1,.32V30H99.5V25.32a13.15,13.15,0,0,0-7-1.92,11.67,11.67,0,0,0-11.72,12"/>
-            <path fill="#008989" d="M101.74,25.6a6.9,6.9,0,0,0,6.59,7.36c3.87,0,6.59-3.3,6.59-7.36s-2.72-7.37-6.59-7.37a6.9,6.9,0,0,0-6.59,7.37m18.61,0c0,6.64-5.37,12-12,12s-12-5.37-12-12,5.37-12,12-12,12,5.37,12,12"/>
-            <path fill="#008989" d="M123.25,34.34h6.25c2.78,0,4-1.12,4-3.25s-1.22-3.24-4-3.24h-6.25Zm0-10.71h5.68c2.29,0,3.61-1,3.61-3s-1.32-3-3.61-3h-5.68Zm-5.18-9.9H130c5.55,0,8.37,3,8.37,6.71A6.37,6.37,0,0,1,134,26.59l0,.05a6.7,6.7,0,0,1,5,6.68c0,4.23-3.08,7.11-8.75,7.11h-12.2Z"/>
-          </svg>
+          <img src="logo.png" alt="Libellen-Runner Logo" width="120" height="42" style="margin-bottom: 5px;" />
         </div>
         <h1>Libellen‑Runner</h1>
         <p>Fliege als Libelle über den Fluss, weiche Zahlenreihen, Seerosen und Vögeln aus, sammle Mücken‑Orbs für Bonuspunkte.</p>
         <p><strong>Power-Ups:</strong> 🛡️ Schutzschild · 🔥 Geschwindigkeitsschub · 🧲 Mücken-Magnet</p>
         <p><strong>Steuerung:</strong> <kbd>Leertaste</kbd> oder <kbd>↑</kbd> Flügelschlag / Sprung · <kbd>P</kbd> Pause · <span class="touch-hint">Tippen für Flügelschlag</span></p>
+        <input type="text" id="playerNameInput" class="name-input" placeholder="Wie heißt du?">
         <a href="#" class="btn" id="start">Losfliegen</a>
       </div>
     </div>
@@ -116,12 +113,13 @@
 (function() {
   const canvas = document.getElementById('game');
   const ctx = canvas.getContext('2d');
-  const overlay = document.getElementById('overlay');
-  const startBtn = document.getElementById('start');
-  const scoreEl = document.getElementById('score');
-  const bestEl = document.getElementById('best');
-  const speedEl = document.getElementById('speed');
-  const powerupIndicatorEl = document.getElementById('powerupIndicator');
+    const overlay = document.getElementById('overlay');
+    const startBtn = document.getElementById('start');
+    const nameInput = document.getElementById('playerNameInput');
+    const scoreEl = document.getElementById('score');
+    const bestEl = document.getElementById('best');
+    const speedEl = document.getElementById('speed');
+    const powerupIndicatorEl = document.getElementById('powerupIndicator');
 
   // Powerup Typen
   const POWERUP_TYPES = {
@@ -163,6 +161,7 @@
     baseSpeed: 320, // px/s world scroll speed
     worldOffset: 0,
     activePowerups: {}, // Aktive Powerups speichern
+    playerName: ''
   };
   bestEl.textContent = state.best;
 
@@ -597,19 +596,25 @@
     ctx.beginPath();
     ctx.arc(0,0,22,0,Math.PI*2);
     ctx.fill();
-    
+
     // Innerer Kern
     ctx.fillStyle = config.color.replace('0.9', '1');
     ctx.beginPath();
     ctx.arc(0,0,10,0,Math.PI*2);
     ctx.fill();
-    
+
     // Glanzeffekt
     ctx.fillStyle = 'rgba(255,255,255,0.8)';
     ctx.beginPath();
     ctx.arc(-3,-3,3,0,Math.PI*2);
     ctx.fill();
-    
+
+    // Icon in der Mitte zeichnen
+    ctx.font = '20px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText(config.icon, 0, 0);
+
     ctx.restore();
   }
 
@@ -777,6 +782,10 @@
   }
 
   function start() {
+    if (!state.playerName) {
+      const entered = nameInput ? nameInput.value.trim() : '';
+      state.playerName = entered || 'Gast';
+    }
     overlay.style.display = 'none'; state.running = true; state.paused = false; reset(); lastTs = performance.now(); requestAnimationFrame(loop);
   }
   function gameOver() {
@@ -785,15 +794,9 @@
     bestEl.textContent = state.best;
     overlay.innerHTML = `<div class="card">
         <div style="text-align: center; margin-bottom: 15px;">
-          <svg xmlns="http://www.w3.org/2000/svg" width="120" height="42" viewBox="0 0 150 52.5" style="margin-bottom: 5px;">
-            <path fill="#008989" d="M54.64,27.4a13.92,13.92,0,0,0-1.12-5.68,13.79,13.79,0,1,0-4.8,15.92,14,14,0,0,0,4.24-4.56A14.49,14.49,0,0,0,54.64,27.4M61,27.4A21,21,0,0,1,32.63,46.23,21,21,0,0,1,32.63,8.57,21,21,0,0,1,61,27.4"/>
-            <path fill="#008989" d="M65.56,42.82H71V24.65h5.4v-4.5H71V13.73H65.56v6.42H62.23v4.5h3.33Z"/>
-            <path fill="#008989" d="M80.82,31.36a11.69,11.69,0,0,0,11.72,12,13.17,13.17,0,0,0,7-1.92V36.75H93.25v4.27a8.41,8.41,0,0,1-1,.31,8.17,8.17,0,0,1-6.43-.87,7.61,7.61,0,0,1-3.49-7.1,7.62,7.62,0,0,1,3.49-7.1,8.16,8.16,0,0,1,6.43-.88,8.34,8.34,0,0,1,1,.32V30H99.5V25.32a13.15,13.15,0,0,0-7-1.92,11.67,11.67,0,0,0-11.72,12"/>
-            <path fill="#008989" d="M101.74,25.6a6.9,6.9,0,0,0,6.59,7.36c3.87,0,6.59-3.3,6.59-7.36s-2.72-7.37-6.59-7.37a6.9,6.9,0,0,0-6.59,7.37m18.61,0c0,6.64-5.37,12-12,12s-12-5.37-12-12,5.37-12,12-12,12,5.37,12,12"/>
-            <path fill="#008989" d="M123.25,34.34h6.25c2.78,0,4-1.12,4-3.25s-1.22-3.24-4-3.24h-6.25Zm0-10.71h5.68c2.29,0,3.61-1,3.61-3s-1.32-3-3.61-3h-5.68Zm-5.18-9.9H130c5.55,0,8.37,3,8.37,6.71A6.37,6.37,0,0,1,134,26.59l0,.05a6.7,6.7,0,0,1,5,6.68c0,4.23-3.08,7.11-8.75,7.11h-12.2Z"/>
-          </svg>
+          <img src="logo.png" alt="Libellen-Runner Logo" width="120" height="42" style="margin-bottom: 5px;" />
         </div>
-        <h1>Game Over</h1>
+        <h1>Game Over, ${state.playerName}!</h1>
         <p>Score: <strong>${Math.floor(state.score)}</strong> · Best: <strong>${state.best}</strong></p>
         <p><small>Tipp: kurze, rhythmische Flügelschläge geben dir mehr Kontrolle.</small></p>
         <a href="#" class="btn" id="restart">Nochmal</a>


### PR DESCRIPTION
## Summary
- replace inline SVG logo with PNG file on entry and game over overlays
- ask player for a name before the game starts and show it on the game-over screen
- render power-ups with their emoji icons and add a style for the magnet power-up
- remove logo.png from the repo for a manual upload later

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b72efcdbd883258e7549ec38193b99