### PR TITLE
Add desert background after score 250

### DIFF
--- a/dragonfly_game.html
+++ b/dragonfly_game.html
@@ -315,23 +315,22 @@
       drawCloud(cloud.x, cloud.y, cloud.size, cloud.opacity);
     }
     
-    if (state.score <= 150) {
+    if (state.score < 150) {
       // Mountains - SWICA Türkistöne
       for (let i = 0; i < 2; i++) {
         const baseY = h * (0.36 + i * 0.05);
-        // SWICA Türkistöne
         ctx.fillStyle = i === 0 ? '#00aaa0' : '#008989';
         ctx.beginPath();
-        const offset = (p * (i + 1)) % (w);
+        const offset = (p * (i + 1)) % w;
         ctx.moveTo(-offset, baseY);
         for (let x = -offset; x <= w - offset + 200; x += 200) {
-          const peakHeight = 80 + i * 30 + Math.sin((x + i*123) * 0.01) * 20;
+          const peakHeight = 80 + i * 30 + Math.sin((x + i * 123) * 0.01) * 20;
           ctx.lineTo(x + 100, baseY - peakHeight);
           ctx.lineTo(x + 200, baseY);
         }
         ctx.lineTo(w, h); ctx.lineTo(0, h); ctx.closePath(); ctx.fill();
       }
-    } else {
+    } else if (state.score < 250) {
       // City skyline
       for (let i = 0; i < 2; i++) {
         const baseY = h * (0.36 + i * 0.05);
@@ -343,6 +342,29 @@
           ctx.fillRect(x, baseY - bHeight, bWidth, bHeight);
         }
       }
+    } else {
+      // Desert with dunes
+      const groundY = h * world.riverY;
+      ctx.fillStyle = '#edc76c';
+      ctx.fillRect(0, groundY, w, h - groundY);
+      for (let i = 0; i < 2; i++) {
+        const baseY = h * (0.36 + i * 0.05);
+        ctx.fillStyle = i === 0 ? '#e0b55b' : '#d1a14a';
+        ctx.beginPath();
+        const offset = (p * (i + 1)) % w;
+        ctx.moveTo(-offset, baseY);
+        for (let x = -offset; x <= w - offset + 200; x += 200) {
+          const duneHeight = 40 + i * 20 + Math.sin((x + i * 87) * 0.01) * 15;
+          ctx.lineTo(x + 100, baseY - duneHeight);
+          ctx.lineTo(x + 200, baseY);
+        }
+        ctx.lineTo(w, h); ctx.lineTo(0, h); ctx.closePath(); ctx.fill();
+      }
+      // Cacti
+      const cactusOffset = (state.worldOffset * 0.6) % 160;
+      for (let x = -cactusOffset; x < w + 160; x += 160) drawCactus(x, groundY, 1);
+      ctx.restore();
+      return;
     }
     // River
     const riverY = h * world.riverY; ctx.fillStyle = '#1a6aa1'; ctx.fillRect(0, riverY, w, h - riverY);
@@ -357,6 +379,26 @@
     // Foreground number sequences (parallax)
     const reedOffset = (state.worldOffset * 1.2) % 80;
     for (let x = -reedOffset; x < w + 80; x += 80) drawReedCluster(x, riverY + 6, 1);
+    ctx.restore();
+  }
+
+  function drawCactus(x, baseY, scale) {
+    ctx.save();
+    ctx.translate(x, baseY);
+    ctx.scale(scale, scale);
+    ctx.fillStyle = '#2f8f2f';
+    // main trunk
+    ctx.fillRect(-5, -40, 10, 40);
+    // left arm
+    ctx.fillRect(-15, -30, 10, 5);
+    ctx.fillRect(-20, -45, 5, 20);
+    // right arm
+    ctx.fillRect(5, -25, 10, 5);
+    ctx.fillRect(15, -40, 5, 20);
+    // rounded top
+    ctx.beginPath();
+    ctx.arc(0, -40, 5, Math.PI, 0);
+    ctx.fill();
     ctx.restore();
   }
   


### PR DESCRIPTION
## Summary
- Switch to a desert scene with dunes and cacti when the score reaches 250
- Include cactus drawing helper for the new background

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d9945e5c8325a636157836f00b8d