### PR TITLE
Add restart option to return to name entry screen

### DIFF
--- a/dragonfly_game.html
+++ b/dragonfly_game.html
@@ -856,9 +856,11 @@
         <p>Score: <strong>${Math.floor(state.score)}</strong> · Best: <strong>${state.best}</strong></p>
         <p><small>Tipp: kurze, rhythmische Flügelschläge geben dir mehr Kontrolle.</small></p>
         <a href="#" class="btn" id="restart">Nochmal</a>
+        <a href="#" class="btn" id="resetGame" style="margin-left:10px;">Neustart</a>
       </div>`;
     overlay.style.display = 'grid';
     overlay.querySelector('#restart').addEventListener('click', (e) => { e.preventDefault(); start(); });
+    overlay.querySelector('#resetGame').addEventListener('click', (e) => { e.preventDefault(); location.reload(); });
   }
 
   let lastTs = performance.now();


### PR DESCRIPTION
## Summary
- Add a "Neustart" button on game over screen to reload page and show the name entry overlay.
- Preserve existing "Nochmal" quick restart option.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7da65dc788325b044b513ab62e721